### PR TITLE
Issue/5 조회수 순위 동시성 테스트 및 캐시 redis로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,9 +33,6 @@ dependencies {
 
 	compileOnly 'org.projectlombok:lombok'
 
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -45,6 +42,9 @@ dependencies {
 
 	implementation 'org.java-websocket:Java-WebSocket:1.5.3'
 
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:testcontainers'
+	testImplementation 'org.mockito:mockito-core'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/joopro/Joosik_Pro/config/RedisConfig.java
+++ b/src/main/java/com/joopro/Joosik_Pro/config/RedisConfig.java
@@ -1,10 +1,14 @@
 package com.joopro.Joosik_Pro.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -15,9 +19,27 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
+    public RedisTemplate<String, Object> redisMakeTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(redisConnectionFactory());
+        template.setConnectionFactory(connectionFactory);
+
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder().build(),
+                ObjectMapper.DefaultTyping.NON_FINAL
+        );
+
+        Jackson2JsonRedisSerializer<Object> jsonSerializer = new Jackson2JsonRedisSerializer<>(mapper, Object.class);
+        template.setValueSerializer(jsonSerializer);
+        template.setHashValueSerializer(jsonSerializer);
+
+
+        template.setKeySerializer(stringSerializer);
+        template.setHashKeySerializer(stringSerializer);
+
+        template.afterPropertiesSet();
         return template;
     }
 

--- a/src/main/java/com/joopro/Joosik_Pro/dto/logindto/LoginResponseDto.java
+++ b/src/main/java/com/joopro/Joosik_Pro/dto/logindto/LoginResponseDto.java
@@ -1,13 +1,38 @@
 package com.joopro.Joosik_Pro.dto.logindto;
 
 import com.joopro.Joosik_Pro.dto.memberdto.MemberDtoResponse;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
 public class LoginResponseDto {
+    @Getter
     private boolean success;
+    @Getter
     private String message;
     private MemberDtoResponse member;
+
+    @Builder
+    public LoginResponseDto(boolean success, String message, MemberDtoResponse member){
+        this.success = success;
+        this.message = message;
+        this.member = member;
+    }
+
+    public static LoginResponseDto success(MemberDtoResponse member){
+        return LoginResponseDto.builder()
+                .success(true)
+                .message("로그인 성공")
+                .member(member)
+                .build();
+    }
+
+    public static LoginResponseDto fail(){
+        return LoginResponseDto.builder()
+                .success(false)
+                .message("비밀번호가 틀렸습니다.")
+                .member(null)
+                .build();
+    }
+
 }

--- a/src/main/java/com/joopro/Joosik_Pro/repository/PostRepository.java
+++ b/src/main/java/com/joopro/Joosik_Pro/repository/PostRepository.java
@@ -118,4 +118,11 @@ public class PostRepository {
                 .getResultList();
     }
 
+    public void increaseViewCount(Long postId, Long count) {
+        em.createQuery("UPDATE Post p SET p.viewCount = p.viewCount + :count WHERE p.id = :id")
+                .setParameter("count", count)
+                .setParameter("id", postId)
+                .executeUpdate();
+    }
+
 }

--- a/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/RedisTopViewRepositoryImpl.java
+++ b/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/RedisTopViewRepositoryImpl.java
@@ -7,8 +7,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -38,11 +40,13 @@ public class RedisTopViewRepositoryImpl implements TopViewRepositoryV2 {
     private static final LinkedHashMap<Long, Post> cache = new LinkedHashMap<>();
     private static final String POPULAR_POSTS_SET_KEY = "popularPostsZSet";
 
+    @Transactional
     @PostConstruct
-    private void init() {
+    protected void init() {
         updateCacheWithDB();
     }
 
+    @Transactional
     @Override
     public void updateCacheWithDBAutomatically() {
         updateCacheWithDB();
@@ -68,7 +72,7 @@ public class RedisTopViewRepositoryImpl implements TopViewRepositoryV2 {
         redisTemplate.delete(POPULAR_POSTS_SET_KEY);
         cache.clear();
 
-        var topPosts = postRepository.getPopularArticles();
+        List<Post> topPosts = postRepository.getPopularArticles();
         for (Post post : topPosts) {
             Long postId = post.getId();
             redisTemplate.opsForZSet().add(POPULAR_POSTS_SET_KEY,

--- a/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/RedisTopViewRepositoryImpl.java
+++ b/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/RedisTopViewRepositoryImpl.java
@@ -1,0 +1,100 @@
+package com.joopro.Joosik_Pro.repository.viewcount;
+
+import com.joopro.Joosik_Pro.domain.Post.Post;
+import com.joopro.Joosik_Pro.repository.PostRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.LinkedHashMap;
+import java.util.Set;
+
+/**
+ * Redis와 zSet을 활용한 Bulk Update 구현
+ *
+ * 최신 인기 글 순위를 정확하게 반영하려면 getPopularPosts 메서드를 호출할 때마다
+ * zSet을 이용해 캐시를 업데이트하는 것이 좋지만, 성능 문제가 발생할 수 있음.
+ * zSet에 쌓인 조회수를 DB에 반영할 때, 새로운 캐시 데이터를 업데이트.
+ *
+ * returnPost 호출 시, 캐시에 값이 있는지 확인:
+ *  캐시에 존재하면 캐시에서 반환.
+ *  캐시에 없으면 DB에서 직접 조회 후 반환.
+ *
+ * 캐시 데이터를 DB에 업데이트할 때:
+ *  캐시에 값이 있으면 zSet에 총 조회수가 저장됨.
+ *  캐시에 값이 없으면 zSet의 조회수가 0부터 시작되므로, 기존 조회수에 zSet의 누적 조회수를 더하여 반영.
+ *
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class RedisTopViewRepositoryImpl implements TopViewRepositoryV2 {
+
+    private final PostRepository postRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final LinkedHashMap<Long, Post> cache = new LinkedHashMap<>();
+    private static final String POPULAR_POSTS_SET_KEY = "popularPostsZSet";
+
+    @PostConstruct
+    private void init() {
+        updateCacheWithDB();
+    }
+
+    @Override
+    public void updateCacheWithDBAutomatically() {
+        updateCacheWithDB();
+    }
+
+    @Override
+    public Post returnPost(Long postId) {
+        Post post = cache.get(postId);
+        if(post == null){
+            post = postRepository.findById(postId);
+        }
+        redisTemplate.opsForZSet().incrementScore(POPULAR_POSTS_SET_KEY, String.valueOf(postId), 1.0);
+        return post;
+    }
+
+    @Override
+    public LinkedHashMap<Long, Post> getPopularPosts() {
+        return cache;
+    }
+
+    private void updateCacheWithDB() {
+        updateViewCountsToDB();
+        redisTemplate.delete(POPULAR_POSTS_SET_KEY);
+        cache.clear();
+
+        var topPosts = postRepository.getPopularArticles();
+        for (Post post : topPosts) {
+            Long postId = post.getId();
+            redisTemplate.opsForZSet().add(POPULAR_POSTS_SET_KEY,
+                    String.valueOf(post.getId()),
+                    (double) post.getViewCount());
+            cache.put(postId, post); // 캐시에 추가
+        }
+    }
+
+    private void updateViewCountsToDB() {
+        Set<String> allPostIds = redisTemplate.opsForZSet().range(POPULAR_POSTS_SET_KEY, 0, -1);
+        if (allPostIds.isEmpty()) return;
+        for (String idStr : allPostIds) {
+            try {
+                Long postId = Long.parseLong(idStr);
+                Double score = redisTemplate.opsForZSet().score(POPULAR_POSTS_SET_KEY, idStr);
+                Post post = cache.get(postId);
+                if(post!= null){
+                    post.setViewCount(score.longValue());
+                }else{
+                    post = postRepository.findById(postId);
+                    post.increaseViewCount(score.longValue());
+                }
+            } catch (Exception e) {
+                log.warn("ZSet 조회수 동기화 실패 - id: {}", idStr, e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV1.java
+++ b/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV1.java
@@ -85,16 +85,6 @@ public class TopViewRepositoryImplV1 implements TopViewRepository{
             Post post = postRepository.findById(entry.getKey());
             post.setViewCount(Long.valueOf(firstValue + entry.getValue()));
             System.out.println(postRepository.findById(entry.getKey()).getViewCount());
-
-            // 이게 왜 안되지?
-//            em.createQuery("UPDATE Post p SET p.viewCount = p.viewCount + :increment WHERE p.id = :postId")
-//                    .setParameter("increment", entry.getValue())
-//                    .setParameter("postId", entry.getKey())
-//                    .executeUpdate();
-//            System.out.println(entry.getKey());
-//            System.out.println(entry.getValue());
-//
-//            System.out.println(postRepository.findById(entry.getKey()).getViewCount());
         }
         tempViewCount.clear();
     }

--- a/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV2.java
+++ b/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV2.java
@@ -33,10 +33,8 @@ public class TopViewRepositoryImplV2 implements TopViewRepository{
     private final EntityManager em;
     private final PostRepository postRepository;
 
-    @Getter //테스트용 Getter
-    private LinkedHashMap<Long, AtomicInteger> cache = new LinkedHashMap<>();
-    @Getter // 테스트용 Getter
-    private LinkedHashMap<Long, Post> returnCache = new LinkedHashMap<>();
+    private static LinkedHashMap<Long, AtomicInteger> cache = new LinkedHashMap<>();
+    private static LinkedHashMap<Long, Post> returnCache = new LinkedHashMap<>();
 
     @Transactional
     @PostConstruct
@@ -100,22 +98,9 @@ public class TopViewRepositoryImplV2 implements TopViewRepository{
 
     // 데이터베이스에 조회수 연동
     public void updateViewCountsToDB(){
-        log.info("updateViewCountsToDB start");
         for(Map.Entry<Long, AtomicInteger> entry : cache.entrySet()) {
-            log.info("entry.getKey() : {}", entry.getKey());
-            log.info("entry.getValue() : {}", entry.getValue());
-
-            log.info("여기다");
-            List<Post> posts = postRepository.findAll();
-            for (Post go : posts) {
-                System.out.println("여기는 되냐");
-                System.out.println("posts: " + go.getId());
-                System.out.println("posts: " + go.getViewCount());
-            }
             Post post = em.find(Post.class, entry.getKey());
-
             if (post != null) {
-                log.info("updateViewCountsToDB: post.setViewCount: {}", entry.getValue().longValue());
                 post.setViewCount(entry.getValue().longValue());
             }else{
                 log.info("null입니다.");
@@ -135,6 +120,12 @@ public class TopViewRepositoryImplV2 implements TopViewRepository{
         this.updateCacheInLocal();
     }
 
+    private static Map<Long, AtomicInteger> getCacheForTest() {
+        return cache;
+    }
 
+    private static LinkedHashMap<Long, Post> getReturnCacheForTest() {
+        return returnCache;
+    }
 
 }

--- a/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV3.java
+++ b/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV3.java
@@ -24,8 +24,9 @@ import java.util.stream.Collectors;
 public class TopViewRepositoryImplV3 implements TopViewRepositoryV2{
 
     private final PostRepository postRepository;
-
+    @Getter
     private static LinkedHashMap<Long, Post> cache = new LinkedHashMap<>();
+    @Getter
     private static final Map<Long, AtomicInteger> tempViewCount = new ConcurrentHashMap<>();
 
     @Transactional

--- a/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV3.java
+++ b/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV3.java
@@ -31,7 +31,12 @@ public class TopViewRepositoryImplV3 implements TopViewRepositoryV2{
 
     @Transactional
     @PostConstruct
-    public void init() {
+    protected void init() {
+        updateCacheWithDB();
+    }
+
+    @Override
+    public void updateCacheWithDBAutomatically(){
         updateCacheWithDB();
     }
 
@@ -43,11 +48,13 @@ public class TopViewRepositoryImplV3 implements TopViewRepositoryV2{
         if(post!= null){
             log.info("2호출됨");
             tempViewCount.computeIfAbsent(postId, id -> new AtomicInteger(0)).incrementAndGet();
+            return post;
         }else{
             log.info("3호출됨");
-            postRepository.increaseViewCount(postId, 1L);
+            Post post2 = postRepository.findById(postId);
+            post2.increaseViewCount(1L);
+            return post2;
         }
-        return post;
     }
 
     @Override

--- a/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV3.java
+++ b/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV3.java
@@ -43,10 +43,9 @@ public class TopViewRepositoryImplV3 implements TopViewRepositoryV2{
         if(post!= null){
             log.info("2호출됨");
             tempViewCount.computeIfAbsent(postId, id -> new AtomicInteger(0)).incrementAndGet();
-//            tempViewCount.put(postId, tempViewCount.getOrDefault(postId, 0) + 1);
         }else{
-            post = postRepository.findById(postId);
-            post.increaseViewCount(1L);
+            log.info("3호출됨");
+            postRepository.increaseViewCount(postId, 1L);
         }
         return post;
     }

--- a/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV3.java
+++ b/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV3.java
@@ -25,9 +25,8 @@ public class TopViewRepositoryImplV3 implements TopViewRepositoryV2{
 
     private final PostRepository postRepository;
 
-    // 테스트용 Getter
-    @Getter private LinkedHashMap<Long, Post> cache = new LinkedHashMap<>();
-    @Getter private static final Map<Long, AtomicInteger> tempViewCount = new ConcurrentHashMap<>();
+    private static LinkedHashMap<Long, Post> cache = new LinkedHashMap<>();
+    private static final Map<Long, AtomicInteger> tempViewCount = new ConcurrentHashMap<>();
 
     @Transactional
     @PostConstruct
@@ -35,6 +34,7 @@ public class TopViewRepositoryImplV3 implements TopViewRepositoryV2{
         updateCacheWithDB();
     }
 
+    @Transactional
     @Override
     public void updateCacheWithDBAutomatically(){
         updateCacheWithDB();
@@ -43,14 +43,11 @@ public class TopViewRepositoryImplV3 implements TopViewRepositoryV2{
     @Override
     public Post returnPost(Long postId) {
         Post post = cache.get(postId);
-        log.info("1호출됨");
 
         if(post!= null){
-            log.info("2호출됨");
             tempViewCount.computeIfAbsent(postId, id -> new AtomicInteger(0)).incrementAndGet();
             return post;
         }else{
-            log.info("3호출됨");
             Post post2 = postRepository.findById(postId);
             post2.increaseViewCount(1L);
             return post2;
@@ -86,5 +83,14 @@ public class TopViewRepositoryImplV3 implements TopViewRepositoryV2{
         }
         tempViewCount.clear();
     }
+
+    private static Map<Long, AtomicInteger> getTempViewCountForTest() {
+        return tempViewCount;
+    }
+
+    private static LinkedHashMap<Long, Post> getCacheForTest() {
+        return cache;
+    }
+
 
 }

--- a/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryV2.java
+++ b/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryV2.java
@@ -10,4 +10,6 @@ public interface TopViewRepositoryV2 {
 
     Post returnPost(Long postId);
 
+    void updateCacheWithDBAutomatically();
+
 }

--- a/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewSchedulerService.java
+++ b/src/main/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewSchedulerService.java
@@ -11,13 +11,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TopViewSchedulerService {
 
-    private final TopViewRepositoryImplV3 topViewRepositoryImplV3;
+    private final TopViewRepositoryV2 topViewRepositoryV2;
 
     @Scheduled(cron = "${scheduler.topview.cron}")
 //    @Transactional
-    public void updateCacheWithDBAutomatically() {
+    public synchronized void updateCacheWithDBAutomatically() {
         log.info("TopView 캐시 및 DB 업데이트 시작");
-        topViewRepositoryImplV3.init();
+        topViewRepositoryV2.updateCacheWithDBAutomatically();
     }
 
 }

--- a/src/main/java/com/joopro/Joosik_Pro/service/MemberService.java
+++ b/src/main/java/com/joopro/Joosik_Pro/service/MemberService.java
@@ -26,7 +26,7 @@ public class MemberService {
     public LoginResponseDto login(String name, String password) {
         List<Member> members = memberRepository.findByName(name);
         if (members.isEmpty()) {
-            return new LoginResponseDto(false, "존재하지 않는 회원입니다.", null);
+            return LoginResponseDto.fail();
         }
 
         // name은 중복 가능성 있으므로 첫 번째 일치 항목 기준
@@ -37,11 +37,10 @@ public class MemberService {
                 for (String roomId : userJoinedRooms) {
                     chatRoomService.subscribe(roomId);
                 }
-                return new LoginResponseDto(true, "로그인 성공", MemberDtoResponse.of(member));
+                return LoginResponseDto.success(MemberDtoResponse.of(member));
             }
         }
-
-        return new LoginResponseDto(false, "비밀번호가 틀렸습니다.", null);
+        return LoginResponseDto.fail();
     }
 
     // 멤버 등록

--- a/src/main/java/com/joopro/Joosik_Pro/service/TopViewService/TopViewService.java
+++ b/src/main/java/com/joopro/Joosik_Pro/service/TopViewService/TopViewService.java
@@ -4,6 +4,7 @@ import com.joopro.Joosik_Pro.domain.Post.Post;
 import com.joopro.Joosik_Pro.repository.viewcount.TopViewRepository;
 import com.joopro.Joosik_Pro.repository.viewcount.TopViewRepositoryV2;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -26,6 +27,7 @@ public class TopViewService {
         return new ArrayList<>(Top100Post.values());
     }
 
+    @Transactional
     // cache에 Post 있다면 반환, 조회수도 한번에 올리기 위해서 내부적으로 처리
     public Post returnPost(Long postId){
         Post post = topViewRepository.returnPost(postId);

--- a/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/RedisTopViewRepositoryImplMockTest.java
+++ b/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/RedisTopViewRepositoryImplMockTest.java
@@ -1,0 +1,111 @@
+package com.joopro.Joosik_Pro.repository.viewcount;
+
+import com.joopro.Joosik_Pro.domain.Member;
+import com.joopro.Joosik_Pro.domain.Post.Post;
+import com.joopro.Joosik_Pro.domain.Post.SingleStockPost;
+import com.joopro.Joosik_Pro.domain.Stock;
+import com.joopro.Joosik_Pro.repository.PostRepository;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+class RedisTopViewRepositoryImplMockTest {
+
+    @Autowired
+    private RedisTopViewRepositoryImpl redisTopViewRepository;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @MockitoBean
+    private PostRepository postRepository;
+
+    private final Long testPostId = 1L;
+
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate.delete("popularPostsZSet");
+
+        Member member = Member.builder()
+                .name("유저B")
+                .password("1234")
+                .email("b@email.com")
+                .build();
+
+        Stock stock = Stock.builder()
+                .companyName("Apple")
+                .sector("Tech")
+                .ticker("AAPL")
+                .build();
+
+        post = SingleStockPost.makeSingleStockPost("애플 분석", member, stock);
+        post.increaseViewCount(100L);
+
+        given(postRepository.getPopularArticles()).willReturn(List.of(post));
+        given(postRepository.findById(testPostId)).willReturn(post);
+
+        setPostId(post, 1L);
+
+        // 캐시 초기화 실행
+        redisTopViewRepository.updateCacheWithDBAutomatically();
+    }
+
+    @AfterEach
+    void teardown(){
+        redisTemplate.delete("popularPostsZSet");
+    }
+
+    @Test
+    @DisplayName("게시글 조회 시 ZSet 점수가 증가해야 한다.")
+    void returnPost() {
+        redisTopViewRepository.returnPost(testPostId);
+
+        Double score = redisTemplate.opsForZSet().score("popularPostsZSet", testPostId.toString());
+        assertThat(score).isEqualTo(101L);
+    }
+
+    @Test
+    @DisplayName("updateViewCountsToDB 호출 시 캐시된 조회수가 DB(Post)에 반영되어야 한다.")
+    void updateViewCountsToDB() {
+        redisTopViewRepository.returnPost(testPostId); // 조회수 증가 1회
+
+        redisTopViewRepository.updateCacheWithDBAutomatically();
+
+        for(Map.Entry<Long, Post> entry : redisTopViewRepository.getPopularPosts().entrySet()){
+            System.out.println("entry.getKey : " + entry.getKey());
+            System.out.println("entry.getValue : " + entry.getValue());
+        }
+
+
+        Post updatedPost = redisTopViewRepository.getPopularPosts().get(testPostId);
+        assertThat(updatedPost.getViewCount()).isEqualTo(101L); // 기존 100 + 1
+    }
+
+    // 실제 객체는 Mockito로 Stubbing 불가, 처음엔 given(post.getId()).willReturn(1L); 썼지만 안됨
+    // 리플렉션 코드
+    private void setPostId(Post post, Long id) {
+        try {
+            Field idField = Post.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(post, id);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/RedisTopViewRepositoryImplTest.java
+++ b/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/RedisTopViewRepositoryImplTest.java
@@ -1,0 +1,107 @@
+package com.joopro.Joosik_Pro.repository.viewcount;
+
+import com.joopro.Joosik_Pro.domain.Member;
+import com.joopro.Joosik_Pro.domain.Post.Post;
+import com.joopro.Joosik_Pro.domain.Post.SingleStockPost;
+import com.joopro.Joosik_Pro.domain.Stock;
+import com.joopro.Joosik_Pro.repository.MemberRepository;
+import com.joopro.Joosik_Pro.repository.PostRepository;
+import com.joopro.Joosik_Pro.repository.StockRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+@Transactional
+class RedisTopViewRepositoryImplTest {
+
+    @Autowired
+    private RedisTopViewRepositoryImpl topViewRepository;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+//    @Mock
+    @Autowired private EntityManager em;
+    @Autowired private PostRepository postRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private StockRepository stockRepository;
+
+    private final Long testPostId = 1L;
+
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate.delete("popularPostsZSet");
+
+        Member member = Member.builder()
+                .name("유저B")
+                .password("1234")
+                .email("b@email.com")
+                .build();
+        memberRepository.save(member);
+
+        Stock stock = Stock.builder()
+                .companyName("Apple")
+                .sector("Tech")
+                .ticker("AAPL")
+                .build();
+        stockRepository.save(stock);
+
+        post = SingleStockPost.makeSingleStockPost("애플 분석", member, stock);
+        postRepository.save(post);
+
+        post.increaseViewCount(100L);
+
+        em.flush();
+        em.clear();
+
+        // 캐시 초기화 실행
+        topViewRepository.updateCacheWithDBAutomatically();
+    }
+
+    @AfterEach
+    void teardown(){
+        redisTemplate.delete("popularPostsZSet");
+    }
+
+    @Test
+    @DisplayName("게시글 조회 시 ZSet 점수가 증가해야 한다.")
+    void returnPost() {
+        topViewRepository.returnPost(testPostId);
+
+        Double score = redisTemplate.opsForZSet().score("popularPostsZSet", testPostId.toString());
+        assertThat(score).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("updateViewCountsToDB 호출 시 캐시된 조회수가 DB(Post)에 반영되어야 한다.")
+    void updateViewCountsToDB() {
+        topViewRepository.returnPost(testPostId); // 조회수 증가 1회
+
+
+        topViewRepository.updateCacheWithDBAutomatically();
+
+        for(Map.Entry<Long, Post> entry : topViewRepository.getPopularPosts().entrySet()){
+            System.out.println("entry.getKey : " + entry.getKey());
+            System.out.println("entry.getValue : " + entry.getValue());
+        }
+
+
+        Post updatedPost = topViewRepository.getPopularPosts().get(testPostId);
+        assertThat(updatedPost.getViewCount()).isEqualTo(101L); // 기존 100 + 1
+    }
+
+}

--- a/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV2SyncTest.java
+++ b/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV2SyncTest.java
@@ -1,10 +1,12 @@
 package com.joopro.Joosik_Pro.repository.viewcount;
 
+import com.joopro.Joosik_Pro.domain.Post.Post;
 import com.joopro.Joosik_Pro.repository.PostRepository;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
@@ -57,7 +59,7 @@ class TopViewRepositoryImplV2SyncTest {
     }
 
     @Test
-    void synchronizeTest() {
+    void synchronizeTest() throws Exception {
         int totalThreads = 200;
         ExecutorService executorService = Executors.newFixedThreadPool(20);
         CountDownLatch latch = new CountDownLatch(totalThreads);
@@ -83,9 +85,27 @@ class TopViewRepositoryImplV2SyncTest {
         }
         executorService.shutdown();
 
+        LinkedHashMap<Long, Post> returnCache = accessReturnCacheByReflection();
+        Map<Long, AtomicInteger> cache = accessCacheByReflection();
+
         assertEquals(1, topViewRepository.getPopularPosts().size());
-        assertEquals(200, topViewRepository.getCache().get(1L).get()); // 캐시에는 200 count 쌓임
-        assertEquals(200, topViewRepository.getReturnCache().get(1L).getViewCount());
+        assertEquals(200, cache.get(1L).get());
+        assertEquals(200, returnCache.get(1L).getViewCount());
         assertEquals(200, postRepository.findById(1L).getViewCount());
     }
+
+    @SuppressWarnings("unchecked")
+    private Map<Long, AtomicInteger> accessCacheByReflection() throws Exception {
+        var method = TopViewRepositoryImplV2.class.getDeclaredMethod("getCacheForTest");
+        method.setAccessible(true);
+        return (Map<Long, AtomicInteger>) method.invoke(topViewRepository);
+    }
+
+    @SuppressWarnings("unchecked")
+    private LinkedHashMap<Long, Post> accessReturnCacheByReflection() throws Exception {
+        var method = TopViewRepositoryImplV2.class.getDeclaredMethod("getReturnCacheForTest");
+        method.setAccessible(true);
+        return (LinkedHashMap<Long, Post>) method.invoke(topViewRepository);
+    }
+
 }

--- a/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV2SyncTest.java
+++ b/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV2SyncTest.java
@@ -17,7 +17,6 @@ import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-<<<<<<< HEAD
 /**
  * TopViewRepositoryImplV2Test 내에
  * synchronizeTest를 테스트 하기 위한 코드

--- a/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV3ExTest.java
+++ b/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV3ExTest.java
@@ -61,7 +61,7 @@ class TopViewRepositoryImplV3ExTest {
 
         when(postRepository.getPopularArticles()).thenReturn(List.of(post1, post2));
 
-        topViewRepositoryImplV3.init();
+        topViewRepositoryImplV3.updateCacheWithDBAutomatically();
     }
 
     @AfterEach
@@ -90,7 +90,7 @@ class TopViewRepositoryImplV3ExTest {
         // Mock 설정
         when(postRepository.findById(post2.getId())).thenReturn(post2);
 
-        topViewRepositoryImplV3.init();
+        topViewRepositoryImplV3.updateCacheWithDBAutomatically();
 
         assertThat(post2.getViewCount()).isEqualTo(5L); // 기존 3 + 2
         assertThat(TopViewRepositoryImplV3.getTempViewCount()).isEmpty();

--- a/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV3Test.java
+++ b/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewRepositoryImplV3Test.java
@@ -65,7 +65,7 @@ class TopViewRepositoryImplV3Test {
         em.flush();
         em.clear();
 
-        topViewRepositoryImplV3.init(); // PostConstruct 수동 호출
+        topViewRepositoryImplV3.updateCacheWithDBAutomatically(); // PostConstruct 수동 호출
     }
 
     @AfterEach
@@ -91,7 +91,7 @@ class TopViewRepositoryImplV3Test {
         topViewRepositoryImplV3.returnPost(post2.getId());
         topViewRepositoryImplV3.returnPost(post2.getId());
 
-        topViewRepositoryImplV3.init(); // updateViewCountsToDB 포함
+        topViewRepositoryImplV3.updateCacheWithDBAutomatically(); // updateViewCountsToDB 포함
 
         Post updatedPost = postRepository.findById(post2.getId());
         assertThat(updatedPost.getViewCount()).isEqualTo(5L); // 기존 3L + 2

--- a/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewServiceTest.java
+++ b/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewServiceTest.java
@@ -1,28 +1,14 @@
 package com.joopro.Joosik_Pro.repository.viewcount;
 
-import com.joopro.Joosik_Pro.domain.Member;
 import com.joopro.Joosik_Pro.domain.Post.Post;
-import com.joopro.Joosik_Pro.domain.Post.SingleStockPost;
-import com.joopro.Joosik_Pro.domain.Stock;
-import com.joopro.Joosik_Pro.dto.memberdto.MemberDtoResponse;
-import com.joopro.Joosik_Pro.repository.MemberRepository;
 import com.joopro.Joosik_Pro.repository.PostRepository;
-import com.joopro.Joosik_Pro.repository.StockRepository;
-import com.joopro.Joosik_Pro.service.MemberService;
-import com.joopro.Joosik_Pro.service.PostService;
-import com.joopro.Joosik_Pro.service.StockService;
 import com.joopro.Joosik_Pro.service.TopViewService.TopViewService;
-import jakarta.persistence.EntityManager;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -53,6 +39,8 @@ public class TopViewServiceTest {
     @Autowired TopViewService topViewService;
     @Autowired TopViewRepositoryImplV3 topViewRepositoryImplV3;
     @Autowired TopViewSchedulerService topViewSchedulerService;
+    @Autowired
+    PostRepository postRepository;
 
 
     @Test
@@ -83,8 +71,11 @@ public class TopViewServiceTest {
         }
         executorService.shutdown();
 
+        topViewRepositoryImplV3.init();
+
         assertEquals(1, topViewService.getPopularArticles().size());
-        assertEquals(500, TopViewRepositoryImplV3.getTempViewCount().get(1L));
+//        assertEquals(500, TopViewRepositoryImplV3.getTempViewCount().get(1L));
+        assertEquals(500, postRepository.findById(1L).getViewCount());
 
     }
 

--- a/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewServiceTest.java
+++ b/src/test/java/com/joopro/Joosik_Pro/repository/viewcount/TopViewServiceTest.java
@@ -30,6 +30,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * -> @Scheduled는 테스트 환경에서는 작동하지 않는다. -> 중간에 직접 호출하는 방식 활용
  *
+ * TopViewService에 updateCacheWithDBAutomatically메서드에 Synchornized를 넣지 않았을 때
+ * current == 100 즉, 업데이트가 한번만 이뤄질때는 동시성 문제가 생기지 않지만
+ * current % 100 == 0 즉, 업데이트(updateCacheWithDBAUtomatically)가 여러 번 이루어지면
+ * 동시성 문제가 생긴다
+ *
+ * DB 반영하고 있는 로직들이 겹쳐서 실행될 수 있다. 따라서 updateCacheWithDBAUtomatically 메서드에 Synchronized를 넣었다.
+ *
+ * Synchornized를 넣는다고 하더라도 totalThread를 598로 해버리면 500이 DB에업데이트되고 98은 캐시에 업데이트 되야 하는데 598이 모두 업데이트 되는 문제가 발생했다.
+ * current == 100이라고 해도 업데이트가 350정도까지 올라가 있는걸 확인했다.
+ *
+ * 캐시 업데이트를 담당하는 스레드의 속도가 매우 빠르다 보니, updateCacheWithDBAutomatically가 실행되기 전에 이미 많은 스레드들이 완료되었다.
+ * incrementAndGet()이 증가하는 속도와 updateCacheWithDBAutomatically의 실행 순서가 맞지 않음을 확인하엿따.
+ *
+ *
+ * 동시성 문제를 해결하려면 인스턴스 단위의 락을 적용하거나 Synchronized 사용을 고민해볼 필요가 있다.
+ * 현재 구조에서는 캐시 업데이트 스레드의 속도가 매우 빨라서, DB 반영 전에 스레드가 먼저 완료될 가능성이 크다.
+ * 그래도 DB 정합성 측면에서는 데이터를 온전히 반영하고 있기 때문에 완벽한 주기를 맞추지는 못하지만 DB에 정확히 반영되는 것을 확인하였다.
  */
 @TestPropertySource(locations = "classpath:application-test.properties")
 @Sql(scripts = "/sync-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
@@ -50,12 +67,14 @@ public class TopViewServiceTest {
         CountDownLatch latch = new CountDownLatch(totalThreads);
         AtomicInteger counter = new AtomicInteger();
 
+        topViewSchedulerService.updateCacheWithDBAutomatically();
+
         for (int i = 0; i < totalThreads; i++) {
             executorService.submit(() -> {
                 try {
                     topViewService.returnPost(1L);
                     int current = counter.incrementAndGet();
-                    if (current == 250) { // 250번째 호출 중에 스케줄러 실행
+                    if (current % 100 == 0) {
                         topViewSchedulerService.updateCacheWithDBAutomatically();
                     }
                 } finally {
@@ -71,7 +90,7 @@ public class TopViewServiceTest {
         }
         executorService.shutdown();
 
-        topViewRepositoryImplV3.init();
+        topViewSchedulerService.updateCacheWithDBAutomatically();
 
         assertEquals(1, topViewService.getPopularArticles().size());
 //        assertEquals(500, TopViewRepositoryImplV3.getTempViewCount().get(1L));
@@ -87,7 +106,7 @@ public class TopViewServiceTest {
      */
     @Test
     void getPopularArticles(){
-        topViewRepositoryImplV3.init();
+        topViewRepositoryImplV3.updateCacheWithDBAutomatically();
 
         List<Post> result = topViewService.getPopularArticles();
         assertThat(result.size()).isEqualTo(1);


### PR DESCRIPTION
## 동시성 테스트 및 캐시 구조 개선 내역

### 동시성 테스트 배경 및 문제

- `TopViewService`의 `updateCacheWithDBAutomatically()` 메서드에 `synchronized` 키워드를 사용하지 않았을 때,
    - `current == 100` 등 업데이트가 **한 번만 일어나는 경우**: **동시성 문제 없음**
    - `current % 100 == 0` 등 **여러 번 업데이트가 일어나는 경우**: **동시성 문제 발생**
        - 여러 스레드가 동시에 DB 업데이트 로직을 실행하면서 **중복 반영** 또는 **정합성 오류** 가능성 존재

### 해결 방안

- `updateCacheWithDBAutomatically()` 메서드에 `synchronized` 적용
- 그러나 **스레드 수가 매우 많을 경우**(`totalThread = 598` 등), 여전히 문제 발생
    - 500개는 DB에 반영되어야 하고, 나머지 98개는 캐시에 머물러야 하지만
        
        **598개 전부 DB에 반영되는 현상** 발생
        
    - 이는 `incrementAndGet()` 호출 속도와 `updateCacheWithDBAutomatically()` 실행 타이밍이 **불일치**하기 때문

### 결과

- 캐시 업데이트 스레드의 속도가 매우 빨라, DB 반영 로직보다 먼저 완료됨
- 결국 정확한 주기 맞춤은 어렵지만, **DB 정합성 자체는 유지**
- 테스트 코드를 통해 코드가 어떻게 작동하는지 **정확히 이해하는 데 도움이 됨**
- 다만 실제 운영에서는 일정 조회수 이상일 때 반영하는 구조가 아니라,
    
    **Scheduler 기반 주기적 동기화** 구조이므로 동시에 DB update 코드가 실행되지는 않을 것이기 떄문에 `synchronized`가 큰 효과를 보지 못할 수도 있음
    

---

## 캐시 구조 개선 (ZSet + Redis 외부 캐시 적용)

### 기존 문제점

- JVM 내부 캐시 사용 → 서버 재시작/스케일 아웃 시 데이터 유실 위험

### 개선 사항

- 캐시를 Redis 기반 **ZSet 구조로 외부 분리**
- 인기글 순위를 정확하게 반영하기 위해,
    - `getPopularPosts()` 호출 시마다 ZSet을 참조해도 되지만, **성능 이슈 고려**
- ReturnPost() 호출 시
    1. 값 반환 시:
        - **캐시에 값이 있으면**: 캐시에서 조회수 반환
        - **없으면**: DB에서 직접 조회 후 반환
    2. 캐시 → DB 반영 시:
        - 캐시에 값이 있다면: ZSet의 총 조회수 반영
        - 캐시에 값이 없다면: ZSet은 0부터 시작 → 기존 DB 조회수 + ZSet 누적치를 더해 반영

---

## 요약

- 동시성 문제는 `synchronized`로 일부 해결했지만, 스레드 속도 이슈로 완벽한 제어는 어려움
- JVM 캐시 → Redis ZSet으로 외부 분리하여, 정합성과 확장성 확보
- 실 운영에선 주기적 동기화 방식(Scheduler)으로 관리 중이며, 정합성 유지 확인

## Reflection API 사용
- 기존에 테스트를 위해서 내부의 자료구조를 Getter로 노출하는 문제 발생
- 이는 자료구조 내부 값을 변경할 수 있는 문제 야기
- getTempViewCount 같은 Private 메서드 만든 후 reflection을 이용하여 테스트 코드에서 활용